### PR TITLE
`sklearn` has been deprecated in favor of `scikit-learn` on pypi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
         "opencv-python",
         "torchvision>=0.4.2",
         "Pillow",
-        "sklearn",
+        "scikit-learn",
         "fairscale",
     ],
     packages=find_packages(exclude=("configs", "tests")),


### PR DESCRIPTION
sklearn has been deprecated and replaced with scikit-learn on pypi. See: https://github.com/scikit-learn/sklearn-pypi-package